### PR TITLE
Replace convert-to-nested-vectors with to-double-array in vectorz-coerce...

### DIFF
--- a/src/main/clojure/mikera/vectorz/matrix_api.clj
+++ b/src/main/clojure/mikera/vectorz/matrix_api.clj
@@ -167,7 +167,7 @@
                    ;; (println (str "Coercing " p))
                    (Scalar. (double (mp/get-0d p)))))
 		    (== 1 dims)
-		      (try (Vectorz/toVector (mp/convert-to-nested-vectors p)) (catch Throwable e nil))
+		      (try (Vectorz/toVector (mp/to-double-array p)) (catch Throwable e nil))
 		    (== 2 dims)
 		      (try (Matrixx/toMatrix (mp/convert-to-nested-vectors p)) (catch Throwable e nil))
 		    :else 


### PR DESCRIPTION
Replace convert-to-nested-vectors with to-double-array in vectorz-coerce*.

This improves the performance of vectorz Vector creation from a double[]
dramatically.
