### PR TITLE
add qr

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,12 +35,12 @@
 		<dependency>
 			<groupId>net.mikera</groupId>
 			<artifactId>vectorz</artifactId>
-			<version>0.32.0</version>
+			<version>0.32.1-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>net.mikera</groupId>
 			<artifactId>core.matrix</artifactId>
-			<version>0.23.0</version>
+			<version>0.23.1-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>criterium</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -35,12 +35,12 @@
 		<dependency>
 			<groupId>net.mikera</groupId>
 			<artifactId>vectorz</artifactId>
-			<version>0.32.0</version>
+			<version>0.33.0</version>
 		</dependency>
 		<dependency>
 			<groupId>net.mikera</groupId>
 			<artifactId>core.matrix</artifactId>
-			<version>0.23.0</version>
+			<version>0.24.0</version>
 		</dependency>
 		<dependency>
 			<groupId>criterium</groupId>

--- a/src/main/clojure/mikera/vectorz/matrix_api.clj
+++ b/src/main/clojure/mikera/vectorz/matrix_api.clj
@@ -234,11 +234,18 @@
 
 (extend-protocol mp/PQRDecomposition
   AMatrix
-    (qr [m options]
+    (qr [^AMatrix m options]
       (let [result (mikera.matrixx.decompose.QR/decompose m)]
-        (select-keys 
-        {:Q (.getQ result) :R (.getR result)}
-          (:return options)))))
+        (cond
+          (nil? options)   ;if options is nil, return all keys
+            {:Q (.getQ result) :R (.getR result)}
+          :else (let [ks (filter (fn [x] (or (= x :Q) (= x :R))) (distinct (options :return)))]   ;remove invalid and duplicate keys
+                  (cond
+                    (== 0 (count ks)) {:a :b}
+                    (== 2 (count ks)) {:Q (.getQ result) :R (.getR result)}
+                    :else (cond
+                            (= :Q (ks 0)) {:Q (.getQ result)}
+                            :else         {:R (.getR result)})))))))
 
 (extend-protocol mp/PTypeInfo
   INDArray

--- a/src/main/clojure/mikera/vectorz/matrix_api.clj
+++ b/src/main/clojure/mikera/vectorz/matrix_api.clj
@@ -237,7 +237,7 @@
     (qr [m options]
       (let [result (mikera.matrixx.decompose.QR/decompose m)]
         (cond
-          (nil? options)   ;if options is nil, return all keys
+          (or (nil? options) (nil? (options :keys)))   ;if options is nil, return all keys
             {:Q (.getQ result) :R (.getR result)}
           :else (let [ks (filter (fn [x] (or (= x :Q) (= x :R))) (distinct (options :return)))]   ;remove invalid and duplicate keys
                   (cond

--- a/src/main/clojure/mikera/vectorz/matrix_api.clj
+++ b/src/main/clojure/mikera/vectorz/matrix_api.clj
@@ -11,6 +11,7 @@
   (:import [mikera.indexz AIndex Index])
   (:import [java.util List])
   (:import [mikera.transformz ATransform])
+  (:import [mikera.matrixx.decompose QR IQRResult])
   (:refer-clojure :exclude [vector?]))
 
 (set! *warn-on-reflection* true)
@@ -230,6 +231,14 @@
                                         ;; (println m vm (shape vm))
                                         (assign! (mp/new-matrix-nd m (shape vm)) vm)))))))
          ['mikera.vectorz.AVector 'mikera.matrixx.AMatrix 'mikera.vectorz.AScalar 'mikera.arrayz.INDArray 'mikera.indexz.AIndex]) ))
+
+(extend-protocol mp/PQRDecomposition
+  AMatrix
+    (qr [m options]
+      (let [result (mikera.matrixx.decompose.QR/decompose m)]
+        (select-keys 
+        {:Q (.getQ result) :R (.getR result)}
+          (:return options)))))
 
 (extend-protocol mp/PTypeInfo
   INDArray

--- a/src/main/clojure/mikera/vectorz/matrix_api.clj
+++ b/src/main/clojure/mikera/vectorz/matrix_api.clj
@@ -244,7 +244,7 @@
                     (== 0 (count ks)) {}
                     (== 2 (count ks)) {:Q (.getQ result) :R (.getR result)}
                     :else (cond
-                            (= :Q (ks 0)) {:Q (.getQ result)}
+                            (= :Q (first ks)) {:Q (.getQ result)}
                             :else         {:R (.getR result)})))))))
 
 (extend-protocol mp/PTypeInfo

--- a/src/main/clojure/mikera/vectorz/matrix_api.clj
+++ b/src/main/clojure/mikera/vectorz/matrix_api.clj
@@ -234,11 +234,18 @@
 
 (extend-protocol mp/PQRDecomposition
   AMatrix
-    (qr [m options]
+    (qr [^AMatrix m options]
       (let [result (mikera.matrixx.decompose.QR/decompose m)]
-        (select-keys 
-        {:Q (.getQ result) :R (.getR result)}
-          (:return options)))))
+        (cond
+          (nil? options)   ;if options is nil, return all keys
+            {:Q (.getQ result) :R (.getR result)}
+          :else (let [ks (filter (fn [x] (or (= x :Q) (= x :R))) (distinct (options :return)))]   ;remove invalid and duplicate keys
+                  (cond
+                    (== 0 (count ks)) {}
+                    (== 2 (count ks)) {:Q (.getQ result) :R (.getR result)}
+                    :else (cond
+                            (= :Q (ks 0)) {:Q (.getQ result)}
+                            :else         {:R (.getR result)})))))))
 
 (extend-protocol mp/PTypeInfo
   INDArray

--- a/src/main/clojure/mikera/vectorz/matrix_api.clj
+++ b/src/main/clojure/mikera/vectorz/matrix_api.clj
@@ -235,14 +235,14 @@
 (extend-protocol mp/PQRDecomposition
   AMatrix
     (qr [m options]
-      (let [result (mikera.matrixx.decompose.QR/decompose m)]
+      (let [result (QR/decompose m)]
         (cond
-          (or (nil? options) (nil? (options :keys)))   ;if options is nil, return all keys
+          (or (nil? options) (nil? (options :return)))   ;if options is nil, return all keys
             {:Q (.getQ result) :R (.getR result)}
           :else (let [ks (filter (fn [x] (or (= x :Q) (= x :R))) (distinct (options :return)))]   ;remove invalid and duplicate keys
                   (cond
-                    (== 0 (count ks)) {}
-                    (== 2 (count ks)) {:Q (.getQ result) :R (.getR result)}
+                    (= 0 (count ks)) {}
+                    (= 2 (count ks)) {:Q (.getQ result) :R (.getR result)}
                     :else (cond
                             (= :Q (first ks)) {:Q (.getQ result)}
                             :else         {:R (.getR result)})))))))

--- a/src/main/clojure/mikera/vectorz/matrix_api.clj
+++ b/src/main/clojure/mikera/vectorz/matrix_api.clj
@@ -234,7 +234,7 @@
 
 (extend-protocol mp/PQRDecomposition
   AMatrix
-    (qr [^AMatrix m options]
+    (qr [m options]
       (let [result (mikera.matrixx.decompose.QR/decompose m)]
         (cond
           (nil? options)   ;if options is nil, return all keys


### PR DESCRIPTION
Hey, do I revert the changes in pom.xml?

After I added this protocol, I did this in core.matrix:

``` clojure
=> (def m (matrix [[1 2 3][4 5 6][7 8 9]]))
=> (set-current-implementation :vectorz)
=> (def qrr (qr m))
=> (mmul (qrr :Q) (qrr :R))
[[0.9999999999999989 1.9999999999999978 2.9999999999999973] [3.9999999999999996 5.0 5.999999999999998] [7.0 7.999999999999999 8.999999999999998]]
=> (def qrr (qr m {:return [:R]}))
=> (def r (qrr :R))
=> (def qrr (qr m {:return [:Q]}))
=> (def q (qrr :Q))
=> (mmul q r)
[[0.9999999999999989 1.9999999999999978 2.9999999999999973] [3.9999999999999996 5.0 5.999999999999998] [7.0 7.999999999999999 8.999999999999998]]
```

and it gave the expected result, but I dont know how to tell if it actually used the vectorz.
