### PR TITLE
Removed unused :name declaration in project.clj.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,6 @@
 ;; This file is proveded as a convenience for Leiningen users
 ;;
-;; The pom.xml is used for official builds, and should be considered the 
+;; The pom.xml is used for official builds, and should be considered the
 ;; definitive source for build configuration.
 ;;
 ;; If you are having trouble building, please check the pom.xml for latest dependency versions
@@ -21,8 +21,7 @@
                  [net.mikera/core.matrix "0.52.0"]
                  ;; [net.mikera/core.matrix "0.47.1" :type "test-jar"] ;; bug in Lein!!!! see: https://github.com/technomancy/leiningen/issues/1975
                  [net.mikera/vectorz "0.62.0"]]
-  
+
   :profiles {:dev {:java-source-paths ["src/test/java"]}}
-  
-  :repositories [["clojars.org" {:url "https://clojars.org/repo"
-                                 :name "Clojars repository"}]])
+
+  :repositories [["clojars.org" {:url "https://clojars.org/repo"}]])


### PR DESCRIPTION
It's not read by leiningen (assuming I've understood correctly) so it might as well not be there, else it might lead someone to believe that it actually does something.